### PR TITLE
[Frontend_excercise] Add tooltip for file path in authorship panel

### DIFF
--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -95,7 +95,10 @@
               span.tooltip-text(v-show="file.active") Click to hide file details
               font-awesome-icon(icon="caret-right", fixed-width, v-show="!file.active")
               span.tooltip-text(v-show="!file.active") Click to show file details
-            span {{ i + 1 }}. &nbsp;&nbsp; {{ file.path }} &nbsp;
+            span {{ i + 1 }}. &nbsp;&nbsp;
+            .tooltip
+              span.tooltip-text(v-show="file.active") This is the file path. Click to hide file details &nbsp;
+              span.tooltip-text(v-show="!file.active") This is the file path. Click to show file details &nbsp;
           span.icons
             a(
               v-bind:href="getFileLink(file, 'commits')", target="_blank"

--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -97,9 +97,9 @@
               span.tooltip-text(v-show="!file.active") Click to show file details
 
             .tooltip
-                span {{ i + 1 }}. &nbsp;&nbsp; {{ file.path }} &nbsp;
-                span.tooltip-text(v-show="file.active") This is the file path. Click to hide file details &nbsp;
-                span.tooltip-text(v-show="!file.active") This is the file path. Click to show file details &nbsp;
+              span {{ i + 1 }}. &nbsp;&nbsp; {{ file.path }} &nbsp;
+              span.tooltip-text(v-show="file.active") This is the file path. Click to hide file details &nbsp;
+              span.tooltip-text(v-show="!file.active") This is the file path. Click to show file details &nbsp;
           span.icons
             a(
               v-bind:href="getFileLink(file, 'commits')", target="_blank"

--- a/frontend/src/tabs/authorship.pug
+++ b/frontend/src/tabs/authorship.pug
@@ -95,10 +95,11 @@
               span.tooltip-text(v-show="file.active") Click to hide file details
               font-awesome-icon(icon="caret-right", fixed-width, v-show="!file.active")
               span.tooltip-text(v-show="!file.active") Click to show file details
-            span {{ i + 1 }}. &nbsp;&nbsp;
+
             .tooltip
-              span.tooltip-text(v-show="file.active") This is the file path. Click to hide file details &nbsp;
-              span.tooltip-text(v-show="!file.active") This is the file path. Click to show file details &nbsp;
+                span {{ i + 1 }}. &nbsp;&nbsp; {{ file.path }} &nbsp;
+                span.tooltip-text(v-show="file.active") This is the file path. Click to hide file details &nbsp;
+                span.tooltip-text(v-show="!file.active") This is the file path. Click to show file details &nbsp;
           span.icons
             a(
               v-bind:href="getFileLink(file, 'commits')", target="_blank"


### PR DESCRIPTION
This is the second excercise for the front end section in [learning the basics](https://reposense.org/RepoSense/dg/learningBasics.html)

```
Add tooltip for file path in authorship panel

In the authorship contribution panel, hovering the mouse on an icon on the file title will 
cause a corresponding tooltip to show up explaining the purpose of the icon. However, 
this does not apply to the file path. This enhancement is for the purpose of practice.

Let's add a tooltip for file path in authorship panel!
```

