### PR TITLE
[Frontend_excercise] Add tooltip for commit message title in zoom panel

### DIFF
--- a/frontend/src/tabs/zoom.pug
+++ b/frontend/src/tabs/zoom.pug
@@ -93,9 +93,11 @@
         v-bind:key="slice.hash",
         v-bind:class="{ 'message-body active': slice.messageBody !== '' }"
       )
-        a.message-title(v-bind:href="getSliceLink(slice)", target="_blank")
-          .within-border {{ slice.messageTitle.substr(0, 50) }}
-          .not-within-border(v-if="slice.messageTitle.length > 50") {{ slice.messageTitle.substr(50) }}
+        .tooltip
+          a.message-title(v-bind:href="getSliceLink(slice)", target="_blank")
+            .within-border {{ slice.messageTitle.substr(0, 50) }}
+            .not-within-border(v-if="slice.messageTitle.length > 50") {{ slice.messageTitle.substr(50) }}
+          span.tooltip-text Click to view the detailed file changes in the commit
         span &nbsp; ({{ slice.insertions }} lines) &nbsp;
         template
           span.fileTypeLabel(


### PR DESCRIPTION
This is the third excercise for the front end section in [learning the basics](https://reposense.org/RepoSense/dg/learningBasics.html)

```
Add tooltip for commit message title in zoom panel

In the commits panel, hovering the mouse over the commit title does not have a corresponding tooltip
showing up explaining the expected outcome upon clicking the title, even though clicking the title will lead
the users to view the commit details. This enhancement is for the purpose of practice.

Let's add tooltip for commit message title in zoom panel!

```